### PR TITLE
docs: readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ jsonparser.onValue = (value, key, parent, stack) => {
 
 ## License
 
-See [LICENSE.md](../../LICENSE).
+See [LICENSE.md](https://opensource.org/license/mit).
 
 [npm-version-badge]: https://badge.fury.io/js/@streamparser%2Fjson.svg
 [npm-badge-url]: https://www.npmjs.com/package/@streamparser/json


### PR DESCRIPTION
fixed the license link, the previous one didn't work